### PR TITLE
Allow us to handle exceptions from libcitygml

### DIFF
--- a/sources/src/parser/parserxercesc.cpp
+++ b/sources/src/parser/parserxercesc.cpp
@@ -280,12 +280,12 @@ namespace citygml
         parser->setContentHandler( &handler );
         parser->setErrorHandler( &handler );
 
-#ifdef NDEBUG
+#if defined(NDEBUG) && !defined(LIBCITYGML_ALLOW_PARSER_EXCEPTION)
         try
         {
 #endif
             parser->parse(stream);
-#ifdef NDEBUG
+#if defined(NDEBUG) && !defined(LIBCITYGML_ALLOW_PARSER_EXCEPTION)
         }
         catch ( const xercesc::XMLException& e )
         {
@@ -332,12 +332,12 @@ namespace citygml
 
         std::shared_ptr<XMLCh> fileName = toXercesString(fname);
 
-#ifdef NDEBUG
+#if defined(NDEBUG) && !defined(LIBCITYGML_ALLOW_PARSER_EXCEPTION)
         try {
 #endif
             xercesc::LocalFileInputSource fileSource(fileName.get());
             return parse(fileSource, params, logger, fname);
-#ifdef NDEBUG
+#if defined(NDEBUG) && !defined(LIBCITYGML_ALLOW_PARSER_EXCEPTION)
         } catch (xercesc::XMLException& e) {
             CITYGML_LOG_ERROR(logger, "Error parsing file " << fname << ": " << e.getMessage());
             return nullptr;


### PR DESCRIPTION
In Debug exceptions were allowed to propogate up to our code, so we can create tiling errors. This also allows us to capture error messages and throw exceptions in our error handler. In Release exceptions were all caught in the library so we couldn't handle them correctly.

Instead of just deleting the `try`/`catch` blocks, I added a `LIBCITYGML_ALLOW_PARSER_EXCEPTION` definition so if we want we can submit this back to main repo and there is a chance they'll take it.