### PR TITLE
Use warnings for recoverable errors

### DIFF
--- a/sources/src/citygml/polygon.cpp
+++ b/sources/src/citygml/polygon.cpp
@@ -84,7 +84,7 @@ namespace citygml {
         }
 
         if (it->second.size() != m_vertices.size()) {
-            CITYGML_LOG_ERROR(m_logger, "Number of texture coordinates (" << it->second.size() << ") for theme "
+            CITYGML_LOG_WARN(m_logger, "Number of texture coordinates (" << it->second.size() << ") for theme "
                              << theme << " in polygon with id " << this->getId() << " does not match number of vertices (" << m_vertices.size()
                               << ").");
         }

--- a/sources/src/citygml/tesselator.cpp
+++ b/sources/src/citygml/tesselator.cpp
@@ -104,7 +104,7 @@ void Tesselator::addContour(const std::vector<TVec3d>& pts, std::vector<std::vec
 
         if (texCoords.size() != pts.size()) {
             if (!texCoords.empty()) {
-                CITYGML_LOG_ERROR(_logger, "Invalid call to 'addContour'. The number of texture coordinates in list " << i << " (" << texCoords.size() << ") "
+                CITYGML_LOG_WARN(_logger, "Invalid call to 'addContour'. The number of texture coordinates in list " << i << " (" << texCoords.size() << ") "
                              "does not match the number of vertices (" << pts.size() << "). The texture coordinates list will be resized which may cause invalid texture coordinates.");
             }
 

--- a/sources/src/parser/appearanceelementparser.cpp
+++ b/sources/src/parser/appearanceelementparser.cpp
@@ -58,7 +58,7 @@ namespace citygml {
         }
 
         if (m_surfaceDataList.empty()) {
-            CITYGML_LOG_ERROR(m_logger, "Appearance node that ends at " << getDocumentLocation() << " has no surfaceData elements.");
+            CITYGML_LOG_WARN(m_logger, "Appearance node that ends at " << getDocumentLocation() << " has no surfaceData elements.");
         }
 
         // assign the theme to all members


### PR DESCRIPTION
The included CityGML logger does not exit on `ERROR`. However, derived loggers may exit on error.

While this is fine for most errors, some errors are recoverable and should not exit. For these errors, use `WARN` instead of `ERROR`.

The errors changed had logic to handle failed cases and do not throw/return on error.

@tfili Can you review?