### PR TITLE
Fix memcpy out of bounds when constructing a vec4 from vec3+scalar.

### DIFF
--- a/sources/include/citygml/vecs.hpp
+++ b/sources/include/citygml/vecs.hpp
@@ -318,7 +318,7 @@ public:
         this->w = w;
     }
 
-    TVec4( const T vec[], const T w ) { memcpy( xyzw, vec, 4 * sizeof(T) ); this->w = w; }
+    TVec4( const T vec[], const T w ) { memcpy( xyzw, vec, 3 * sizeof(T) ); this->w = w; }
 
     TVec4( const T vec[] ) { memcpy( xyzw, vec, 4 * sizeof(T) ); }
 };


### PR DESCRIPTION
A `TVec4` can be constructed from a `TVec3` plus a scalar, but the code was incorrectly copying 4 elements from the `TVec3`.

This was picked up by `-Werror=array-bounds` in GCC v8.3.0.