### PR TITLE
Swapped lat long

### DIFF
--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -62,7 +62,7 @@ public:
         }
 
         const char* flipLatLon = std::getenv("CITYGML_FLIP_LAT_LON");
-        if (strcmp(flipLatLon, "1") == 0)
+        if (flipLatLon && strcmp(flipLatLon, "1") == 0)
         {
             std::swap(p.x, p.y);
         }

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -62,7 +62,7 @@ public:
         }
 
         const char* flipLatLon = std::getenv("CITYGML_FLIP_LAT_LON");
-        if (strcmp(flipLatLon, "1"))
+        if (strcmp(flipLatLon, "1") == 0)
         {
             std::swap(p.x, p.y);
         }

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -61,6 +61,7 @@ public:
             return;
         }
 
+        std::swap(p.x, p.y);
         m_transformation->Transform( 1, &p.x, &p.y, &p.z );
 
         p.z *= m_verticalToMeters;

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -25,6 +25,9 @@ public:
 		, m_transformation(nullptr)
 		, m_logger(logger)
     {
+        const char* flipLatLon = std::getenv("CITYGML_FLIP_LAT_LON");
+        m_flipLatLon = (flipLatLon && strcmp(flipLatLon, "1") == 0);
+
         OGRErr err = m_destSRS.SetFromUserInput(destURN.c_str());
         m_destSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 
@@ -41,6 +44,7 @@ public:
 		, m_verticalToMeters(1.0)
 		, m_transformation(nullptr)
 		, m_logger(other.m_logger)
+        , m_flipLatLon(other.m_flipLatLon)
 	{
     }
 
@@ -61,9 +65,7 @@ public:
             return;
         }
 
-        const char* flipLatLon = std::getenv("CITYGML_FLIP_LAT_LON");
-        if (flipLatLon && strcmp(flipLatLon, "1") == 0)
-        {
+        if (m_flipLatLon) {
             std::swap(p.x, p.y);
         }
         m_transformation->Transform( 1, &p.x, &p.y, &p.z );
@@ -142,6 +144,7 @@ private:
 
     OGRCoordinateTransformation* m_transformation;
     std::shared_ptr<citygml::CityGMLLogger> m_logger;
+    bool m_flipLatLon;
 };
 
 namespace citygml {

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -25,11 +25,8 @@ public:
 		, m_transformation(nullptr)
 		, m_logger(logger)
     {
-        const char* flipLatLon = std::getenv("CITYGML_FLIP_LAT_LON");
-        m_flipLatLon = (flipLatLon && strcmp(flipLatLon, "1") == 0);
-
         OGRErr err = m_destSRS.SetFromUserInput(destURN.c_str());
-        m_destSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+        m_destSRS.SetAxisMappingStrategy(OAMS_AUTHORITY_COMPLIANT);
 
         if (err != OGRERR_NONE) {
             CITYGML_LOG_ERROR(m_logger, "Could not create OGRSpatialReference for destination SRS " << destURN << ". OGR error code: " << err << ".");
@@ -44,7 +41,6 @@ public:
 		, m_verticalToMeters(1.0)
 		, m_transformation(nullptr)
 		, m_logger(other.m_logger)
-        , m_flipLatLon(other.m_flipLatLon)
 	{
     }
 
@@ -65,9 +61,6 @@ public:
             return;
         }
 
-        if (m_flipLatLon) {
-            std::swap(p.x, p.y);
-        }
         m_transformation->Transform( 1, &p.x, &p.y, &p.z );
 
         p.z *= m_verticalToMeters;
@@ -144,7 +137,6 @@ private:
 
     OGRCoordinateTransformation* m_transformation;
     std::shared_ptr<citygml::CityGMLLogger> m_logger;
-    bool m_flipLatLon;
 };
 
 namespace citygml {

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -61,7 +61,11 @@ public:
             return;
         }
 
-        std::swap(p.x, p.y);
+        const char* flipLatLon = std::getenv("CITYGML_FLIP_LAT_LON");
+        if (strcmp(flipLatLon, "1"))
+        {
+            std::swap(p.x, p.y);
+        }
         m_transformation->Transform( 1, &p.x, &p.y, &p.z );
 
         p.z *= m_verticalToMeters;

--- a/sources/src/parser/geocoordinatetransformer.cpp
+++ b/sources/src/parser/geocoordinatetransformer.cpp
@@ -26,7 +26,10 @@ public:
 		, m_logger(logger)
     {
         OGRErr err = m_destSRS.SetFromUserInput(destURN.c_str());
-        m_destSRS.SetAxisMappingStrategy(OAMS_AUTHORITY_COMPLIANT);
+
+        const char* useSrsOrdering = std::getenv("CITYGML_USE_SRS_ORDERING");
+        auto strategy = (useSrsOrdering && strcmp(useSrsOrdering, "1") == 0) ? OAMS_AUTHORITY_COMPLIANT : OAMS_TRADITIONAL_GIS_ORDER;
+        m_destSRS.SetAxisMappingStrategy(strategy);
 
         if (err != OGRERR_NONE) {
             CITYGML_LOG_ERROR(m_logger, "Could not create OGRSpatialReference for destination SRS " << destURN << ". OGR error code: " << err << ".");


### PR DESCRIPTION
@keyboardspecialist ~I had to do this for some japan data too so I hijacked your branch. We should try and detect this but for now instead of using a branch, I think we should just add an envvar to the released version so we can use it when we need to.~

I thinks I fixed it for real. See https://gdal.org/en/latest/tutorials/osr_api_tut.html#crs-and-axis-order

We need to test his a bunch before we can merge. I'll create a asset-pipeline PR with it so we can run some tests.

## Testing
- Run `./citygmlswayzetests` in the `asset-pipeline` `update-libcitygml` branch - there was a test added to sets the env var
- Verify everything passes
- For extra validation you can run `CITYGML_USE_SRS_ORDERING=1 ./citygmlswayzetests`
- Verify there are failures with the Lat/Lon being swapped