### PR TITLE
Disable XML external entity resolution

### DIFF
--- a/sources/src/parser/parserxercesc.cpp
+++ b/sources/src/parser/parserxercesc.cpp
@@ -278,6 +278,7 @@ namespace citygml
 
         xercesc::SAX2XMLReader* parser = xercesc::XMLReaderFactory::createXMLReader();
         parser->setFeature(xercesc::XMLUni::fgSAX2CoreNameSpaces, false);
+        parser->setFeature(xercesc::XMLUni::fgXercesDisableDefaultEntityResolution, true);
         parser->setContentHandler( &handler );
         parser->setErrorHandler( &handler );
 


### PR DESCRIPTION
Disables XML external entity resolution to address [XXE](https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing) (XML External Entity Injection) vulnerability.